### PR TITLE
Updating some items that are causing bugs in the example projects

### DIFF
--- a/example-with-codegen/src/types/global-fetch.d.ts
+++ b/example-with-codegen/src/types/global-fetch.d.ts
@@ -1,0 +1,1 @@
+declare type GlobalFetch = WindowOrWorkerGlobalScope

--- a/example/src/components/my-component/my-component.tsx
+++ b/example/src/components/my-component/my-component.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from '@stencil/core';
+import { Component, Prop, h } from '@stencil/core';
 import ApolloClient from 'apollo-boost';
 import gql from 'graphql-tag';
 

--- a/example/src/components/my-functional-component/my-functional-component.tsx
+++ b/example/src/components/my-functional-component/my-functional-component.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from '@stencil/core';
+import { Component, Prop, h } from '@stencil/core';
 import ApolloClient from 'apollo-boost';
 import gql from 'graphql-tag';
 import { ApolloProvider, Query, Mutation } from 'stencil-apollo';

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -4,7 +4,8 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <title>Stencil Apollo Starter</title>
-  <script src="/build/app.js"></script>
+  <script type="module" src="/build/app.esm.js"></script>
+  <script nomodule src="/build/app.js"></script>
 
 </head>
 <body>

--- a/example/src/types/global-fetch.d.ts
+++ b/example/src/types/global-fetch.d.ts
@@ -1,0 +1,1 @@
+declare type GlobalFetch = WindowOrWorkerGlobalScope


### PR DESCRIPTION
- Declaring global-fetch type to prevent “Global-Fetch is not defined” error

- Updating index.html files to  include two scripts using the modern ES Module script pattern for both /example and /example-with-codegen projects

- Importing “h” from @stencil/core into example project components to prevent "h  function must be imported from "@stencil/core" by each component using JSX"